### PR TITLE
Fixing some visual things on printed reservation tags

### DIFF
--- a/userscripts/reservation-list-css.user.js
+++ b/userscripts/reservation-list-css.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Clean up reservations list for printing tags - DEV
 // @namespace    https://github.com/laurenipsum/TTL
-// @version      1.0.1
+// @version      1.1
 // @description  Modify the TTL myTurn reservations list for display and for printing reservation tags
 // @author       ipsum
 // @match        https://tacomatoollibrary.myturn.com/library/orgInventory/listReservations*
@@ -13,13 +13,12 @@
     "use strict";
 
     var css = "/* always present, not just in print CSS */\n\n";
+
     css += "/* hide the membership type badge */\n";
     css += "span .badge { display: none; }\n\n";
 
     css += "/* hide the mailto envelope icons */\n";
-    css += "a[href^=\"mailto:\"] {\n";
-    css += "    display: none;\n";
-    css += "}\n\n";
+    css += "a[href^=\"mailto:\"] { display: none; }\n\n";
 
     css += "/* make the alert text for problem items show up on the page */\n";
     css += ".badge-danger::after {\n";
@@ -45,9 +44,7 @@
     css += "}\n\n";
 
     css += "/* style the date if unfulfilled order date has passed */\n";
-    css += ".unfulfilled-reservation-date {\n";
-    css += "    display: block;\n";
-    css += "}\n\n";
+    css += ".unfulfilled-reservation-date { display: block; }\n\n";
 
     css += "/* style the pickup days missed message */\n";
     css += ".pickup-days-missed {\n";
@@ -55,9 +52,11 @@
     css += "    color: #F3565D;\n";
     css += "    font-size: 1.5rem;\n";
     css += "}\n\n";
-    css += ".hidden-xs, .hidden-sm, .hidden-md {\n"
-    css += "   display: none;\n";
-    css += "}\n\n";
+
+    css += ".hidden-xs, .hidden-sm, .hidden-md { display: none; }\n\n";
+
+    css += "/* make reservation notes bigger */\n";
+    css += "div.reservation-notes { font-size: 15px !important; }\n\n";
 
     css += "/* print stylesheet only */\n";
     css += "@media print {\n\n";
@@ -72,8 +71,9 @@
     css += "    /* hide button rows */\n";
     css += "    div.panel-body > div:nth-child(1) > div.col-sm-7.col-sm-push-5.text-right.margin-bottom-10 { display: none; }\n\n";
 
-    css += "    /* add page break after each reservation */\n";
-    css += "    .panel.reservation { break-after: page !important; }\n\n";
+    css += "    /* page break after each reservation, except the last one */\n";
+    css += "    .panel.reservation:not(:last-child) {\n";
+    css += "        break-after: page !important; }\n\n";
 
     css += "    /* make the order status badges bigger */\n";
     css += "    .badge.pull-right { display: none !important; }\n\n";
@@ -85,8 +85,8 @@
     css += "    table.table { font-size: 25px !important; }\n\n";
 
     css += "    /* adjusting relative widths of dates and names */\n";
-    css += "    .col-sm-7 { width: 25%; font-size: 14px; }\n";
-    css += "    .col-sm-5 { width: 75%; }\n";
+    css += "    .col-sm-7 { width: 35%; font-size: 14px;}\n";
+    css += "    .col-sm-5 { width: 50%; }\n";
     css += "    .col-xs-8.col-sm-9 { width: 90% !important; }\n";
     css += "    .col-xs-4.col-sm-3 { width: 10%; }\n\n";
 
@@ -94,6 +94,24 @@
     css += "    th.col-xs-1 { width: 0px !important; }\n";
     css += "    th.col-xs-3 { width: 15%; }\n";
     css += "    th.col-xs-4 { width: 55%; }\n\n";
+
+    css += "     /* i don't want smalls */\n";
+    css += "    small { font-size: inherit !important; }\n\n";
+
+    css += "    /* i don't want the new history icon to print */\n";
+    css += "    i.fa-history { display: none !important; }\n\n";
+
+    css += "    /* hide the edit link on admin notes when printing  */\n";
+    css += "    div.col-xs-3.col-sm-1.text-center { display: none !important; }\n\n";
+
+    css += "    /* for any col-sm-9 that contains a reservation notes div, make it 100% width to fill the space left by the display:none edit column and also to make it wrap so the \"admin notes\" label is stacked on top*/\n";
+    css += "    .col-sm-9:has(.reservation-notes) { width: 100% !important; }\n\n";
+
+    css += "    /* target the location column (3rd td) to make it a monospace serif font for better legibility of I, l, and 1  */\n";
+    css += "    div.reservation table.table tbody tr td:nth-child(3) { font-family: monospace, serif !important; }\n\n";
+
+    css += "    /* make reservation table headers bigger */\n";
+    css += "    div.reservation table thead tr th { font-size: 20px !important; }\n\n";
 
     css += "    /* make alert icons bigger when printing */\n";
     css += "    .badge-danger, .reservation-alert, .reservation-alert i {\n";


### PR DESCRIPTION
Making column headers and admin notes bigger, hiding a new myTurn icon that we don't need, and changing location to monospace font so we can tell the difference between I, l, and 1